### PR TITLE
Put inline chunks of code in tvars instead of leaving them out of translate tags completely.

### DIFF
--- a/app.py
+++ b/app.py
@@ -153,8 +153,8 @@ def process_code_tag(text, tvar_code_id=0):
     if not content:
         return text
     # Wrap the content in <translate> tags
-    wrapped_content = f'<tvar name=code{tvar_code_id}>{content}</tvar>'
-    return f"{prefix}{wrapped_content}{suffix}"
+    wrapped_content = f'<tvar name=code{tvar_code_id}>{prefix}{content}{suffix}</tvar>'
+    return wrapped_content
 
 def process_div(text):
     """


### PR DESCRIPTION
This PR address the things mentioned the things mentioned in [T393255](https://phabricator.wikimedia.org/T393255). 

This is done by placing the code as addressed in the description in between tvar rather than separately. 