### PR TITLE
fix:items in list are applied translate tags on their type

### DIFF
--- a/app.py
+++ b/app.py
@@ -309,7 +309,7 @@ def process_item(text):
     item_content = text[offset:].strip()
     if not item_content:
         return text
-    return text[:offset] + ' ' + _wrap_in_translate(item_content) + '\n'
+    return text[:offset] + ' ' + convert_to_translatable_wikitext(item_content) + '\n'
 
 class double_brackets_types(Enum):
     wikilink = 1


### PR DESCRIPTION
This PR fixes the items in a list not being applied translate tags as intended by the rules stated. 

It closes [link](https://phabricator.wikimedia.org/T413520)