### PR TITLE
fix: wrap entire section heading in <translate> tags 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,10 @@ instance/
 *.pylint.d/
 *.pydist/
 *.pytest_cache/
+*.cache/
+*.coverage.*
+*.bak
+*.tmp
+*.swp
+*.swo
+*.swn

--- a/app.py
+++ b/app.py
@@ -516,7 +516,8 @@ def process_template(text):
 # --- Section Heading Handler ---
 def process_section_heading(text):
     """
-    Processes section headings like ==Title== and wraps the heading text in <translate> tags.
+    Processes section headings like ==Title== and wraps the entire heading in <translate> tags,
+    with the tags on their own lines per MediaWiki translation guidelines.
     """
     # Match ==Title==, ===Subsection===, etc.
     match = re.match(r'^(=+)([^=]+)(=+)$', text.strip())
@@ -524,8 +525,8 @@ def process_section_heading(text):
         return text
     level = match.group(1)
     heading_text = match.group(2).strip()
-    # Reconstruct with same number of = on both sides
-    return f'{level}<translate>{heading_text}</translate>{level}'
+    # Wrap the entire heading (including == markers) in <translate> tags on their own lines
+    return f'<translate>\n{level}{heading_text}{level}\n</translate>'
 
 def process_raw_url(text):
     """

--- a/tests.py
+++ b/tests.py
@@ -6,7 +6,19 @@ class TestTranslatableWikitext(unittest.TestCase):
     def test_section_headers(self):
         self.assertEqual(
             convert_to_translatable_wikitext("==HELLO=="),
-            "<translate>==HELLO==</translate>"  # Removed the \n\n that was expected
+            "<translate>\n==HELLO==\n</translate>"
+        )
+
+    def test_section_heading_strips_spaces(self):
+        self.assertEqual(
+            convert_to_translatable_wikitext("== Example =="),
+            "<translate>\n==Example==\n</translate>"
+        )
+
+    def test_section_headings_multiple_levels_with_body(self):
+        self.assertEqual(
+            convert_to_translatable_wikitext("== Example ==\n\nlorem ipsum\n\n=== Second example ===\n\nlorem ipsum"),
+            "<translate>\n==Example==\n</translate>\n\n<translate>lorem ipsum</translate>\n\n<translate>\n===Second example===\n</translate>\n\n<translate>lorem ipsum</translate>"
         )
 
     def test_file_tag_translations(self):


### PR DESCRIPTION
Instead of wrapping only the heading text (==<translate>text</translate>==), the entire heading including == markers is now wrapped with translate tags on their own lines (<translate>\n==text==\n</translate>). This preserves heading context for translators and enables automatic language anchors without needing {{anchor}} workarounds.